### PR TITLE
ERDs Using PlantUML for Object groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chai": "^4",
     "globby": "^8",
     "mocha": "^5",
+    "node-plantuml": "^0.9.0",
     "nyc": "^14",
     "ts-node": "^8",
     "tslint": "^5"

--- a/src/shared/contenttypes.ts
+++ b/src/shared/contenttypes.ts
@@ -47,6 +47,17 @@ interface ObjectFieldContent {
     additionalInfo: string;
 }
 
+interface PumlEntity {
+    name: string;
+    fields: Array<PumlField>
+}
+
+interface PumlField {
+    name: string,
+    type: string,
+    typeAdditionalInfo?: string
+}
+
 interface TriggersContent {
     counter: number;
     groups: Array<TriggerGroupContent>;
@@ -79,4 +90,4 @@ interface TriggerDuplicate {
     triggers: string;
 }
 
-export {IndexContent, ContentLink, ObjectsContent, ObjectGroupContent, ObjectContent, ObjectFieldContent, TriggersContent, TriggerGroupContent, TriggerContent, TriggerDuplicate}
+export {IndexContent, ContentLink, ObjectsContent, ObjectGroupContent, ObjectContent, ObjectFieldContent, PumlEntity, PumlField, TriggersContent, TriggerGroupContent, TriggerContent, TriggerDuplicate}

--- a/templates/common/styles.ejs
+++ b/templates/common/styles.ejs
@@ -27,4 +27,12 @@
     nav .doc-header {
         margin-bottom: -2em;
     }
+
+    #erd a {
+        display: block;
+    }
+
+    #erd object {
+        pointer-events: none;
+    }
 </style>

--- a/templates/objects/group.ejs
+++ b/templates/objects/group.ejs
@@ -14,7 +14,7 @@
                 <li class="breadcrumb-item"><a href="objects.html">Objects</a></li>
                 <li class="breadcrumb-item active" aria-current="page"><%= content.title %></li>
             </ol>
-        </nav>    
+        </nav>
         <div class="jumbotron jumbotron-fluid doc-header">
             <div class="container">
                 <h1 class="display-4"><%= content.title %></h1>
@@ -29,12 +29,13 @@
             <% content.menuItems.forEach(function(menuItem){ %>
                 <a class="nav-link pb-0" href="#<%= menuItem.href %>"><%= menuItem.title %></a>
             <% }); %>
-        </nav>        
+            <a class="nav-link pb-0" href="#erd">ERD</a>
+        </nav>
         <div class="mt-5"></div>
         <% content.objects.forEach(function(object){ %>
         <div class="card mb-5">
             <h3 class="card-header bg-info text-white"><a name="<%= object.name %>"><%= object.label %></a></h5>
-            <div class="card-body">        
+            <div class="card-body">
                 <h6 class="card-subtitle mb-2 text-muted"><strong>API Name : </strong><%= object.name %></h6>
                 <p><%= object.sfObject.description %></p>
                 <% if (typeof object.recordTypes == 'object' && object.recordTypes && object.recordTypes.length>0) { %>
@@ -108,6 +109,15 @@
             </div>
         </div>
     <% }); %>
+        <h3 class="card-header bg-info text-white"><a name="ERD">ERD</a></h3>
+        <div id="erd" class="text-center">
+            <a href="<%= content.name %>-erd.svg" target="_BLANK">
+                <object type="image/svg+xml" data="<%= content.name %>-erd.svg">
+                    <!-- Fall back -->
+                    <img src="<%= content.name %>-erd.svg" alt="ERD for <%= content.name %> object" />
+                </object>
+            </a>
+        </div>
     </div>
     <%- include ('../common/footer') %>
 </body>

--- a/templates/objects/objects-puml.ejs
+++ b/templates/objects/objects-puml.ejs
@@ -1,0 +1,33 @@
+@startuml
+
+'Hide the spot
+hide circle
+
+'Hide the stereotype
+hide stereotype
+
+hide <<external-group>> members
+
+skinparam class {
+    BackgroundColor<<external-group>> LightBlue
+}
+
+'Entities
+<% content.entities.forEach(function(object){ %> entity <%= object.name %> {
+    --
+    <% object.fields.forEach(function(field){ %> <%= field.name %> : <%= field.type %> <% if (field.typeAdditionalInfo) { %> (<%= field.typeAdditionalInfo %>) <% }; %>
+    <% }); %>
+}
+<% }); %>
+'Non-group Entities
+<% content.nonGroupEntities.forEach(function(nonGroupObject){ %> entity <%= nonGroupObject %> <<external-group>> {
+}
+<% }); %>
+
+'Relationships
+<% for (let src in content.relationships) {
+    for (let target in content.relationships[src]) { %>
+        <%= src %>  }o..o| <%= target %>
+    <% }
+}; %>
+@enduml


### PR DESCRIPTION
Implement basic ERDs for Object groups using PlantUML.

I've used EJS here, and although it's not used for generating markup I think it works well as a generic JS templating engine, and makes use of the existing generator.

I do create an extra object for passing into the generator, mostly because I didn't want to use the values that existed in the other object as they had Markup in (I think it was `field.AdditionalInfo`), perhaps this could be stripped out and then the markup added elsewhere?