### PR TITLE
Hotfix/business process

### DIFF
--- a/src/commands/bbdoc/doc.ts
+++ b/src/commands/bbdoc/doc.ts
@@ -59,7 +59,8 @@ Report generated at report/index.html
       mkdirSync(imageDir);
     }
 
-    const sourceDir = this.flags['source-dir'];
+    let sourceDir = this.flags['source-dir'];
+    sourceDir = sourceDir.endsWith('/') ? sourceDir : sourceDir + '/';
 
     // load the config, using the default if nothing provided via flags
     let config;

--- a/src/shared/processors/object/objects.ts
+++ b/src/shared/processors/object/objects.ts
@@ -263,7 +263,9 @@ class ObjectProcessor {
         let recTypes=getDirectoryEntries(recTypesDir);
         for (let idx=0, len=recTypes.length; idx<len; idx++) {
             let recTypeMd=parseXMLToJS(join(recTypesDir, recTypes[idx]));
-            contentObj.recordTypes.push(recTypeMd.RecordType);
+            if (recTypeMd.RecordType){
+                contentObj.recordTypes.push(recTypeMd.RecordType);
+            }
         }
     }
 


### PR DESCRIPTION
Fix a couple of issues I was having:

1. It looks like BusinessProcess metadata gets retrieved by sfdx into the recordTypes subdirectory which then causes an error on template generation. Just check we actually have a recordType in objects.ts.

2. If I didn't put a trailing / on my source directory nothing would happen - this is because the processors append directly onto this string so we'd get /defaultobjects. Fix is path of least resistance for this one rather than handling the processors.